### PR TITLE
BE307_Corrección-agregar/eliminar-estudiante-de-grupo

### DIFF
--- a/funread_backend/StudentsGroups/views.py
+++ b/funread_backend/StudentsGroups/views.py
@@ -80,7 +80,6 @@ def add_new(request):
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response("teacher or student already registered", status=status.HTTP_400_BAD_REQUEST)
         else:
             #Capture error messages
             non_field_errors = serializer.errors.get('non_field_errors', [])
@@ -100,7 +99,6 @@ def add_new(request):
             #If it is another error, return the errors
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     except OperationalError:
-        return JsonResponse({"error": "La base de datos no está disponible en este momento. Intentelo de nuevo más tarde."},status=status.HTTP_503_SERVICE_UNAVAILABLE)
         return JsonResponse({"error": "The database is not available at this time, please try again later."},status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
 # Elimina un elemento de la lista StudentsGroups

--- a/funread_backend/StudentsGroups/views.py
+++ b/funread_backend/StudentsGroups/views.py
@@ -81,8 +81,27 @@ def add_new(request):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response("teacher or student already registered", status=status.HTTP_400_BAD_REQUEST)
+        else:
+            #Capture error messages
+            non_field_errors = serializer.errors.get('non_field_errors', [])
+            #If the register already exist in the database (a unique combination of one register exists)
+            if non_field_errors and non_field_errors[0] == 'The fields userid, groupscreateid must make a unique set.':
+                userid = request.data.get('userid')
+                groupscreateid = request.data.get('groupscreateid')
+                existing_instance = StudentsGroups.objects.filter(userid=userid, groupscreateid=groupscreateid).first()
+                if existing_instance:
+                    existing_instance.isactive = 1
+                    existing_instance.save()
+                    return Response({
+                        'message': 'Existing register successfully updated',
+                        'data': StudentsGroupsSerializer(existing_instance).data
+                    }, status=status.HTTP_200_OK)
+            
+            #If it is another error, return the errors
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     except OperationalError:
         return JsonResponse({"error": "La base de datos no está disponible en este momento. Intentelo de nuevo más tarde."},status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        return JsonResponse({"error": "The database is not available at this time, please try again later."},status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
 # Elimina un elemento de la lista StudentsGroups
 @api_view(['PUT'])


### PR DESCRIPTION
Corrección de error al agregar estudiante a un grupo.

El error se debe a que el modelo StudentsGroups contiene una condición de combinación única de variables 'userid' y 'groupscreateid', con lo que no puede crearse otro registro con la misma combinación.

Entonces cuando la persona agrega  el estudiante el serialisador responde un True en una validación en el metodo add_new en el archivo views.py, entonces al ser true se crea el registro.

Pero cuando la persona elimina al estudiante del grupo, solo se modifica un atributo para que no se muestre más. No se borra realmente el registro.

Entonces cuando se se agrega nuevamente el estudiante al grupo, el serialisador devuelve un false cuando hace las validaciones, porque verifica que la combinación única existe en un registro en la tabla.  Eso retorna un false al método add_new en views.py y el método no crea el registro.

Para solucionarlo, hice un else después de la validación, donde verifica si el error es por la combinación única que indica que ya existe el registro, entonces en ves de crearlo, solo lo busca y lo actualiza, su parámetro isactive de 0 a 1 nuevamente, para que se muestre en el front end.